### PR TITLE
ci: add jsr check

### DIFF
--- a/.github/workflows/check-on-pr.yml
+++ b/.github/workflows/check-on-pr.yml
@@ -38,3 +38,13 @@ jobs:
         with:
           commit_message: "style: auto fix"
           branch: ${{ github.head_ref }}
+
+  jsr-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup
+
+      - name: Run jsr check
+        run: npx jsr publish --dry-run


### PR DESCRIPTION
This pull request adds a new job to the GitHub Actions workflow to run a JSR check on pull requests.

* [`.github/workflows/check-on-pr.yml`](diffhunk://#diff-eac40e914145753bedc45d7d699ca2a57fb36132675eed3620d8fb39c8979ce0R41-R50): Added a new job `jsr-check` that runs on `ubuntu-latest` and includes steps to checkout the repository, set up the environment, and run the JSR check using `npx jsr publish --dry-run`.